### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,15 +1,15 @@
 zbox
 ====
 
-.. image:: https://pypip.in/version/zbox/badge.svg
+.. image:: https://img.shields.io/pypi/v/zbox.svg
     :target: https://pypi.python.org/pypi/zbox/
     :alt: Latest Version
 
-.. image:: https://pypip.in/py_versions/zbox/badge.svg
+.. image:: https://img.shields.io/pypi/pyversions/zbox.svg
     :target: https://pypi.python.org/pypi/zbox/
     :alt: Supported Python versions
 
-.. image:: https://pypip.in/wheel/zbox/badge.svg
+.. image:: https://img.shields.io/pypi/wheel/zbox.svg
     :target: https://pypi.python.org/pypi/zbox/
     :alt: Wheel Status
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20zbox))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `zbox`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.